### PR TITLE
MainWindowViewModelのリファクタリング: 新規プロジェクトダイアログのMVVM適合化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 .idea/.idea.Metasia/.idea
+.idea/

--- a/Metasia.Core/Objects/LayerObject.cs
+++ b/Metasia.Core/Objects/LayerObject.cs
@@ -47,11 +47,11 @@ namespace Metasia.Core.Objects
         {
             double resolution_level_x = e.ActualResolution.Width / e.TargetResolution.Width;
             double resolution_level_y = e.ActualResolution.Height / e.TargetResolution.Height;
-            
+
             List<MetasiaObject> ApplicateObjects = new();
-            foreach (var obj in Objects) 
+            foreach (var obj in Objects)
             {
-                if(obj.IsExistFromFrame(frame) && obj is IMetaDrawable && obj.IsActive)
+                if (obj.IsExistFromFrame(frame) && obj is IMetaDrawable && obj.IsActive)
                 {
                     ApplicateObjects.Add(obj);
                 }
@@ -61,7 +61,7 @@ namespace Metasia.Core.Objects
 
             if (e.Bitmap is null) e.Bitmap = new SKBitmap((int)(e.ActualResolution.Width), (int)(e.ActualResolution.Height));
 
-            
+
 
             foreach (var obj in ApplicateObjects)
             {
@@ -111,7 +111,7 @@ namespace Metasia.Core.Objects
 
                         double width = express.TargetSize.Value.Width * (scale / 100f);
                         double height = express.TargetSize.Value.Height * (scale / 100f);
-                        
+
                         SKRect drawPos = new SKRect()
                         {
                             Left = (float)((e.TargetResolution.Width - width) / 2 + x) * (e.ActualResolution.Width / e.TargetResolution.Width),
@@ -126,7 +126,7 @@ namespace Metasia.Core.Objects
 
                 express.Dispose();
             }
-            
+
             e.ActualSize = new SKSize(e.Bitmap.Width, e.Bitmap.Height);
             e.TargetSize = e.TargetResolution;
         }
@@ -169,6 +169,34 @@ namespace Metasia.Core.Objects
 
                 express.Dispose();
             }
+        }
+
+        /// <summary>
+        /// 指定されたオブジェクトを指定された範囲で重複せず配置できるかどうかを判定する
+        /// </summary>
+        /// <param name="objectToCheck">配置を確認するオブジェクト</param>
+        /// <param name="newStartFrame">新しい開始フレーム</param>
+        /// <param name="newEndFrame">新しい終了フレーム</param>
+        /// <returns>配置可能ならtrue, 不可能ならfalse</returns>
+
+        public bool CanPlaceObjectAt(MetasiaObject objectToCheck, int newStartFrame, int newEndFrame)
+        {
+            //新しい範囲がそもそも無効なら弾く
+            if (newStartFrame > newEndFrame) return false;
+
+            //範囲内に重複があるかどうか
+            foreach (var existingObject in Objects)
+            {
+                //同じオブジェクトは除外
+                if (existingObject.Id == objectToCheck.Id) continue;
+
+                if (newStartFrame <= existingObject.EndFrame && newEndFrame >= existingObject.StartFrame)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         

--- a/Metasia.Editor/App.axaml.cs
+++ b/Metasia.Editor/App.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Metasia.Editor.Models.EditCommands;
 using Metasia.Editor.Services;
 using Metasia.Editor.ViewModels;
 using Metasia.Editor.Views;
@@ -33,7 +34,8 @@ namespace Metasia.Editor
 
 				var services = new ServiceCollection();
 				services.AddSingleton<IFileDialogService>(new FileDialogService(desktop.MainWindow));
-				Services = services.BuildServiceProvider();
+                services.AddSingleton<IEditCommandManager>(new EditCommandManager());
+                Services = services.BuildServiceProvider();
 			}
 
 			base.OnFrameworkInitializationCompleted();

--- a/Metasia.Editor/App.axaml.cs
+++ b/Metasia.Editor/App.axaml.cs
@@ -29,11 +29,13 @@ namespace Metasia.Editor
 			{
 				desktop.MainWindow = new MainWindow
 				{
-					DataContext = new MainWindowViewModel(),
+					DataContext = Services.GetService<MainWindowViewModel>(),
 				};
 
 				var services = new ServiceCollection();
 				services.AddSingleton<IFileDialogService>(new FileDialogService(desktop.MainWindow));
+services.AddSingleton<INewProjectDialogService, NewProjectDialogService>();
+services.AddSingleton<MainWindowViewModel>();
                 Services = services.BuildServiceProvider();
 			}
 

--- a/Metasia.Editor/App.axaml.cs
+++ b/Metasia.Editor/App.axaml.cs
@@ -34,7 +34,6 @@ namespace Metasia.Editor
 
 				var services = new ServiceCollection();
 				services.AddSingleton<IFileDialogService>(new FileDialogService(desktop.MainWindow));
-                services.AddSingleton<IEditCommandManager>(new EditCommandManager());
                 Services = services.BuildServiceProvider();
 			}
 

--- a/Metasia.Editor/Models/EditCommands/Commands/ClipResizeCommand.cs
+++ b/Metasia.Editor/Models/EditCommands/Commands/ClipResizeCommand.cs
@@ -1,0 +1,39 @@
+﻿// Metasia.Editor/Models/EditCommands/Commands/ClipResizeCommand.cs
+using Metasia.Core.Objects;
+using System;
+
+namespace Metasia.Editor.Models.EditCommands.Commands
+{
+    public class ClipResizeCommand : IEditCommand
+    {
+        public string Description { get; }
+
+        private readonly MetasiaObject _targetObject;
+        private readonly int _oldStartFrame;
+        private readonly int _oldEndFrame;
+        private readonly int _newStartFrame;
+        private readonly int _newEndFrame;
+
+
+        public ClipResizeCommand(MetasiaObject targetObject, int oldStartFrame, int newStartFrame, int oldEndFrame, int newEndFrame)
+        {
+            _targetObject = targetObject;
+            _oldStartFrame = oldStartFrame;
+            _oldEndFrame = oldEndFrame;
+            _newStartFrame = newStartFrame;
+            _newEndFrame = newEndFrame;
+        }
+
+        public void Execute()
+        {
+            _targetObject.StartFrame = _newStartFrame;
+            _targetObject.EndFrame = _newEndFrame;
+        }
+
+        public void Undo()
+        {
+            _targetObject.StartFrame = _oldStartFrame;
+            _targetObject.EndFrame = _oldEndFrame;
+        }
+    }
+}

--- a/Metasia.Editor/Models/EditCommands/Commands/LayerIsActiveChangeCommand.cs
+++ b/Metasia.Editor/Models/EditCommands/Commands/LayerIsActiveChangeCommand.cs
@@ -1,0 +1,33 @@
+using Metasia.Core.Objects;
+
+namespace Metasia.Editor.Models.EditCommands.Commands;
+
+public class LayerIsActiveChangeCommand: IEditCommand
+{
+    public string Description { get; } = string.Empty;
+    
+    private LayerObject _targetLayerObject;
+    private bool _afterActive;
+    private bool _beforeActive;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="targetLayerObject">有効無効を切り替えたいレイヤー</param>
+    /// <param name="isActive">変更後の値</param>
+    public LayerIsActiveChangeCommand(LayerObject targetLayerObject, bool isActive)
+    {
+        _targetLayerObject = targetLayerObject;
+        _afterActive = isActive;
+        _beforeActive = targetLayerObject.IsActive;
+    }
+    public void Execute()
+    {
+        _targetLayerObject.IsActive = _afterActive;
+    }
+
+    public void Undo()
+    {
+        _targetLayerObject.IsActive = _beforeActive;
+    }
+}

--- a/Metasia.Editor/Models/EditCommands/EditCommandManager.cs
+++ b/Metasia.Editor/Models/EditCommands/EditCommandManager.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Metasia.Editor.Models.EditCommands
+{
+    /// <summary>
+    /// 戻る進むの履歴を保存する編集をEditCommandでやるクラス
+    /// </summary>
+    public class EditCommandManager : IEditCommandManager
+    {
+        public bool CanUndo => undoStack.Count > 0;
+
+        public bool CanRedo => redoStack.Count > 0;
+
+
+        private Stack<IEditCommand> undoStack = new();
+        private Stack<IEditCommand> redoStack = new();
+
+        public void Execute(IEditCommand command)
+        {
+            command.Execute();
+            undoStack.Push(command);
+            redoStack.Clear();  //redoは新しいコマンド実行時にクリアしちゃう
+        }
+
+        public void Undo()
+        {
+            if (undoStack.Count > 0)
+            {
+                var command = undoStack.Pop();
+                command.Undo();
+                redoStack.Push(command);
+            }
+        }
+
+        public void Redo()
+        {
+            if (redoStack.Count > 0)
+            {
+                var command = redoStack.Pop();
+                command.Execute();
+                undoStack.Push(command);
+            }
+        }
+
+        public void Clear()
+        {
+            undoStack.Clear();
+            redoStack.Clear();
+        }
+    }
+}

--- a/Metasia.Editor/Models/EditCommands/IEditCommand.cs
+++ b/Metasia.Editor/Models/EditCommands/IEditCommand.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Metasia.Editor.Models.EditCommands
+﻿namespace Metasia.Editor.Models.EditCommands
 {
     public interface IEditCommand
     {

--- a/Metasia.Editor/Models/EditCommands/IEditCommand.cs
+++ b/Metasia.Editor/Models/EditCommands/IEditCommand.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Metasia.Editor.Models.EditCommands
+{
+    public interface IEditCommand
+    {
+        /// <summary>
+        /// コマンドが行う編集の説明
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// コマンドを実行
+        /// </summary>
+        void Execute();
+
+        /// <summary>
+        /// 巻き戻し処理を実行
+        /// </summary>
+        void Undo();
+    }
+}

--- a/Metasia.Editor/Models/EditCommands/IEditCommandManager.cs
+++ b/Metasia.Editor/Models/EditCommands/IEditCommandManager.cs
@@ -19,6 +19,21 @@ namespace Metasia.Editor.Models.EditCommands
         public bool CanRedo { get; }
 
         /// <summary>
+        /// コマンドが実行されたときに発火するイベント
+        /// </summary>
+        event EventHandler<IEditCommand> CommandExecuted;
+
+        /// <summary>
+        /// Undoが実行されたときに発火するイベント
+        /// </summary>
+        event EventHandler<IEditCommand> CommandUndone;
+
+        /// <summary>
+        /// Redoが実行されたときに発火するイベント
+        /// </summary>
+        event EventHandler<IEditCommand> CommandRedone;
+
+        /// <summary>
         /// コマンドを実行する
         /// </summary>
         /// <param name="command">実行するコマンド</param>
@@ -28,6 +43,7 @@ namespace Metasia.Editor.Models.EditCommands
         /// Undoを実行する
         /// </summary>
         public void Undo();
+        
 
         /// <summary>
         /// Undoしたコマンドを再実行(Redo)する

--- a/Metasia.Editor/Models/EditCommands/IEditCommandManager.cs
+++ b/Metasia.Editor/Models/EditCommands/IEditCommandManager.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Metasia.Editor.Models.EditCommands
+{
+    public interface IEditCommandManager
+    {
+        /// <summary>
+        /// Undoできるかどうか
+        /// </summary>
+        public bool CanUndo { get; }
+
+        /// <summary>
+        /// Redoできるかどうか
+        /// </summary>
+        public bool CanRedo { get; }
+
+        /// <summary>
+        /// コマンドを実行する
+        /// </summary>
+        /// <param name="command">実行するコマンド</param>
+        public void Execute(IEditCommand command);
+
+        /// <summary>
+        /// Undoを実行する
+        /// </summary>
+        public void Undo();
+
+        /// <summary>
+        /// Undoしたコマンドを再実行(Redo)する
+        /// </summary>
+        public void Redo();
+
+        /// <summary>
+        /// 履歴をクリアする
+        /// </summary>
+        public void Clear();
+    }
+}

--- a/Metasia.Editor/Services/INewProjectDialogService.cs
+++ b/Metasia.Editor/Services/INewProjectDialogService.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using Metasia.Editor.Models.ProjectGenerate;
+
+namespace Metasia.Editor.Services
+{
+    public interface INewProjectDialogService
+    {
+        Task<NewProjectDialogResult?> ShowNewProjectDialogAsync();
+    }
+
+    public class NewProjectDialogResult
+    {
+        public bool Result { get; set; }
+        public string ProjectPath { get; set; }
+        public ProjectInfo ProjectInfo { get; set; }
+        public ProjectTemplate SelectedTemplate { get; set; }
+    }
+}

--- a/Metasia.Editor/Services/NewProjectDialogService.cs
+++ b/Metasia.Editor/Services/NewProjectDialogService.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Metasia.Editor.Models.ProjectGenerate;
+using Metasia.Editor.Views;
+
+namespace Metasia.Editor.Services
+{
+    public class NewProjectDialogService : INewProjectDialogService
+    {
+        public async Task<NewProjectDialogResult?> ShowNewProjectDialogAsync()
+        {
+            var window = App.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
+                ? desktop.MainWindow
+                : null;
+
+            if (window == null) return null;
+
+            var dialog = new NewProjectDialog();
+            var result = await dialog.ShowDialog<bool>(window);
+
+            if (result)
+            {
+                return new NewProjectDialogResult
+                {
+                    Result = result,
+                    ProjectPath = dialog.ProjectPath,
+                    ProjectInfo = dialog.ProjectInfo,
+                    SelectedTemplate = dialog.SelectedTemplate
+                };
+            }
+            return null;
+        }
+    }
+}

--- a/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
@@ -37,7 +37,7 @@ namespace Metasia.Editor.ViewModels.Controls
             set 
             {
                 this.RaiseAndSetIfChanged(ref _frame_per_DIP, value);
-                ChangeFramePerDIP();
+                RecalculateSize();
             } 
         }
 
@@ -79,6 +79,15 @@ namespace Metasia.Editor.ViewModels.Controls
             TargetObject = targetObject;
             this.parentTimeline = parentTimeline;
             IsSelecting = false;
+        }
+
+        /// <summary>
+        /// クリップのサイズを再計算する
+        /// </summary>
+        public void RecalculateSize()
+        {
+            Width = (TargetObject.EndFrame - TargetObject.StartFrame + 1) * Frame_Per_DIP;
+            StartFrame = TargetObject.StartFrame * Frame_Per_DIP;
         }
 
         public void ClipClick()
@@ -148,19 +157,13 @@ namespace Metasia.Editor.ViewModels.Controls
                 }
                 parentTimeline.RunEditCommand(command);
 
-                ChangeFramePerDIP();
+                RecalculateSize();
             }
 
             _isDragging = false;
             _dragHandleName = string.Empty;
 
             Console.WriteLine(pointerPositionXOnCanvas);
-        }
-
-        private void ChangeFramePerDIP()
-        {
-            Width = (TargetObject.EndFrame - TargetObject.StartFrame + 1) * Frame_Per_DIP;
-            StartFrame = TargetObject.StartFrame * Frame_Per_DIP;
         }
     }
 }

--- a/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
@@ -52,10 +52,25 @@ namespace Metasia.Editor.ViewModels.Controls
         private double startFrame;
         private bool isSelecting;
 
+        /// <summary>
+        /// ドラッグ中かどうかを示すフラグ
+        /// </summary>
         private bool _isDragging = false;
+
+        /// <summary>
+        /// ドラッグされているのが始端か終端かを示す
+        /// </summary>
         private string _dragHandleName = string.Empty;  // "StartHandle" または "EndHandle"
+
+        /// <summary>
+        /// ドラッグ開始時のポインタ位置
+        /// </summary>
         private double _dragStartX = 0;
-        private int _initialDragFrame = 0; // ドラッグ開始時の始端あるいは終端のフレーム
+
+        /// <summary>
+        /// ドラッグ開始時の始端あるいは終端のフレーム
+        /// </summary>
+        private int _initialDragFrame = 0;
 
         private TimelineViewModel parentTimeline;
 
@@ -71,6 +86,11 @@ namespace Metasia.Editor.ViewModels.Controls
             parentTimeline.ClipSelect(this);
         }
 
+        /// <summary>
+        /// ドラッグ開始時の処理
+        /// </summary>
+        /// <param name="handleName">StartHandle あるいは EndHandle</param>
+        /// <param name="pointerPositionXOnCanvas">ポインタの初期位置</param>
         public void StartDrag(string handleName, double pointerPositionXOnCanvas)
         {
             _isDragging = true;
@@ -86,6 +106,10 @@ namespace Metasia.Editor.ViewModels.Controls
             //ドラッグ中になにかするならここに書く
         }
 
+        /// <summary>
+        /// ドラッグ終了時の処理
+        /// </summary>
+        /// <param name="pointerPositionXOnCanvas">ポインタの最後の位置</param>
         public void EndDrag(double pointerPositionXOnCanvas)
         {
             if (!_isDragging || string.IsNullOrEmpty(_dragHandleName))
@@ -99,6 +123,8 @@ namespace Metasia.Editor.ViewModels.Controls
 
             int finalNewFrame = _initialDragFrame + frameChange;
 
+            // ドラッグが始端か終端かによって、新しいフレームを計算する
+            // オブジェクトの長さが1未満にならないように制限する
             if (_dragHandleName == "StartHandle")
             {
                 finalNewFrame = Math.Min(finalNewFrame, TargetObject.EndFrame - 1);
@@ -108,6 +134,7 @@ namespace Metasia.Editor.ViewModels.Controls
                 finalNewFrame = Math.Max(finalNewFrame, TargetObject.StartFrame + 1);
             }
 
+            //もしフレームが変わっていたらコマンドを実行
             if (finalNewFrame != _initialDragFrame)
             {
                 IEditCommand command;

--- a/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
@@ -1,4 +1,7 @@
-﻿using Metasia.Core.Objects;
+﻿using Avalonia;
+using Metasia.Core.Objects;
+using Metasia.Editor.Models.EditCommands;
+using Metasia.Editor.Models.EditCommands.Commands;
 using ReactiveUI;
 using System;
 using System.Collections.Generic;
@@ -48,7 +51,12 @@ namespace Metasia.Editor.ViewModels.Controls
         private double _frame_per_DIP;
         private double startFrame;
         private bool isSelecting;
-        
+
+        private bool _isDragging = false;
+        private string _dragHandleName = string.Empty;  // "StartHandle" または "EndHandle"
+        private double _dragStartX = 0;
+        private int _initialDragFrame = 0; // ドラッグ開始時の始端あるいは終端のフレーム
+
         private TimelineViewModel parentTimeline;
 
         public ClipViewModel(MetasiaObject targetObject, TimelineViewModel parentTimeline)
@@ -61,6 +69,65 @@ namespace Metasia.Editor.ViewModels.Controls
         public void ClipClick()
         {
             parentTimeline.ClipSelect(this);
+        }
+
+        public void StartDrag(string handleName, double pointerPositionXOnCanvas)
+        {
+            _isDragging = true;
+            _dragHandleName = handleName;
+            _dragStartX = pointerPositionXOnCanvas;
+            _initialDragFrame = (handleName == "StartHandle") ? TargetObject.StartFrame : TargetObject.EndFrame;
+
+            Console.WriteLine(pointerPositionXOnCanvas);
+        }
+
+        public void UpdateDrag(double pointerPositionXOnCanvas)
+        {
+            //ドラッグ中になにかするならここに書く
+        }
+
+        public void EndDrag(double pointerPositionXOnCanvas)
+        {
+            if (!_isDragging || string.IsNullOrEmpty(_dragHandleName))
+            {
+                return;
+            }
+
+            double deltaX = pointerPositionXOnCanvas - _dragStartX;
+            double frameDelta = deltaX / Frame_Per_DIP;
+            int frameChange = (int)Math.Round(frameDelta);
+
+            int finalNewFrame = _initialDragFrame + frameChange;
+
+            if (_dragHandleName == "StartHandle")
+            {
+                finalNewFrame = Math.Min(finalNewFrame, TargetObject.EndFrame - 1);
+            }
+            else
+            {
+                finalNewFrame = Math.Max(finalNewFrame, TargetObject.StartFrame + 1);
+            }
+
+            if (finalNewFrame != _initialDragFrame)
+            {
+                IEditCommand command;
+                if (_dragHandleName == "StartHandle")
+                {
+                    command = new ClipResizeCommand(TargetObject, TargetObject.StartFrame, finalNewFrame, TargetObject.EndFrame, TargetObject.EndFrame);
+                }
+                else
+                {
+                    command = new ClipResizeCommand(TargetObject, TargetObject.StartFrame, TargetObject.StartFrame, TargetObject.EndFrame, finalNewFrame);
+                }
+                parentTimeline.RunEditCommand(command);
+
+                ChangeFramePerDIP();
+            }
+
+            _isDragging = false;
+            _dragHandleName = string.Empty;
+
+            Console.WriteLine(pointerPositionXOnCanvas);
         }
 
         private void ChangeFramePerDIP()

--- a/Metasia.Editor/ViewModels/Controls/LayerButtonViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/LayerButtonViewModel.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Metasia.Editor.Models.EditCommands.Commands;
 
 namespace Metasia.Editor.ViewModels.Controls
 {
@@ -18,16 +19,19 @@ namespace Metasia.Editor.ViewModels.Controls
             set => this.RaiseAndSetIfChanged(ref _buttonText, value);
         }
 
+        private TimelineViewModel _parentTimelineViewModel;
         private LayerObject targetLayerObject;
 
         private string _buttonText = "Layer";
-        public LayerButtonViewModel(LayerObject targetLayerObject) 
+        public LayerButtonViewModel(TimelineViewModel parentTimelineViewModel, LayerObject targetLayerObject) 
         {
+            _parentTimelineViewModel = parentTimelineViewModel;
             this.targetLayerObject = targetLayerObject;
 
             ButtonClick = ReactiveCommand.Create(() =>
             {
-                targetLayerObject.IsActive = !targetLayerObject.IsActive;
+                var command = new LayerIsActiveChangeCommand(targetLayerObject, !targetLayerObject.IsActive);
+                _parentTimelineViewModel.RunEditCommand(command);
             });
 
             ButtonText = targetLayerObject.Name;

--- a/Metasia.Editor/ViewModels/Controls/LayerCanvasViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/LayerCanvasViewModel.cs
@@ -65,6 +65,17 @@ namespace Metasia.Editor.ViewModels.Controls
             }
         }
 
+        /// <summary>
+        /// レイヤーにあるクリップの大きさを再計算する
+        /// </summary>
+        public void RecalculateSize()
+        {
+            foreach (var clip in ClipsAndBlanks)
+            {
+                clip.RecalculateSize();
+            }
+        }
+
         private void ChangeFramePerDIP()
         {
             foreach (var clip in ClipsAndBlanks)

--- a/Metasia.Editor/ViewModels/MainWindowViewModel.cs
+++ b/Metasia.Editor/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,7 @@ using Avalonia.Controls;
 using Metasia.Editor.Models.Projects;
 using Metasia.Editor.Models.FileSystem;
 using Metasia.Editor.Models.ProjectGenerate;
+using Metasia.Editor.Models.EditCommands;
 namespace Metasia.Editor.ViewModels
 {
 	public class MainWindowViewModel : ViewModelBase
@@ -42,10 +43,10 @@ namespace Metasia.Editor.ViewModels
 
 		public MainWindowViewModel()
 		{
-			
 
 
-			SaveEditingProject = ReactiveCommand.Create(SaveEditingProjectExecuteAsync);
+
+            SaveEditingProject = ReactiveCommand.Create(SaveEditingProjectExecuteAsync);
 			LoadEditingProject = ReactiveCommand.Create(LoadEditingProjectExecuteAsync);
 			CreateNewProject = ReactiveCommand.Create(CreateNewProjectExecuteAsync);
 			

--- a/Metasia.Editor/ViewModels/MainWindowViewModel.cs
+++ b/Metasia.Editor/ViewModels/MainWindowViewModel.cs
@@ -24,10 +24,6 @@ namespace Metasia.Editor.ViewModels
 {
 	public class MainWindowViewModel : ViewModelBase
 	{
-		public string Greeting => "Welcome to Avalonia!";
-
-		//public PlayerViewModel playerViewModel { get; }
-		
 		public PlayerParentViewModel PlayerParentVM { get; }
 
 		public InspectorViewModel inspectorViewModel { get; }
@@ -39,6 +35,25 @@ namespace Metasia.Editor.ViewModels
 		public ICommand SaveEditingProject { get; }
 		public ICommand LoadEditingProject { get; }
 		public ICommand CreateNewProject { get; }
+		
+		public ICommand Undo { get; }
+		
+		public ICommand Redo { get; }
+
+		public bool CanUndo
+		{
+			get => _canUndo;
+			set => this.RaiseAndSetIfChanged(ref _canUndo, value);
+		}
+		
+		public bool CanRedo
+		{
+			get => _canRedo;
+			set => this.RaiseAndSetIfChanged(ref _canRedo, value);
+		}
+		
+		private bool _canUndo = false;
+		private bool _canRedo = false;
 
 
 		public MainWindowViewModel()

--- a/Metasia.Editor/ViewModels/MainWindowViewModel.cs
+++ b/Metasia.Editor/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ using Metasia.Editor.Models.Projects;
 using Metasia.Editor.Models.FileSystem;
 using Metasia.Editor.Models.ProjectGenerate;
 using Metasia.Editor.Models.EditCommands;
+using Metasia.Editor.Services;
 namespace Metasia.Editor.ViewModels
 {
 	public class MainWindowViewModel : ViewModelBase
@@ -41,12 +42,16 @@ namespace Metasia.Editor.ViewModels
 		public ICommand Redo { get; }
 		
 
-		public MainWindowViewModel()
+private readonly INewProjectDialogService _newProjectDialogService;
+		public MainWindowViewModel(INewProjectDialogService newProjectDialogService)
+				{
 		{
 
 
 
-            SaveEditingProject = ReactiveCommand.Create(SaveEditingProjectExecuteAsync);
+            				_newProjectDialogService = newProjectDialogService;
+
+				SaveEditingProject = ReactiveCommand.Create(SaveEditingProjectExecuteAsync);
 			LoadEditingProject = ReactiveCommand.Create(LoadEditingProjectExecuteAsync);
 			CreateNewProject = ReactiveCommand.Create(CreateNewProjectExecuteAsync);
 
@@ -69,24 +74,14 @@ namespace Metasia.Editor.ViewModels
 		{
 			try
 			{
-				var window = App.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop
 					? desktop.MainWindow
 					: null;
 				
-				if (window == null) return;
 				
-				var dialog = new NewProjectDialog();
-				var result = await dialog.ShowDialog<bool>(window);
 
-				if (result)
 				{
-					MetasiaEditorProject editorProject = ProjectGenerator.CreateProject(dialog.ProjectPath, dialog.ProjectInfo, dialog.SelectedTemplate);
-					PlayerParentVM.LoadProject(editorProject);
-				}
-			}
 			catch (Exception ex)
 			{
-				Debug.WriteLine($"新規プロジェクト作成エラー: {ex.Message}");
 			}
 		}
 
@@ -130,4 +125,3 @@ namespace Metasia.Editor.ViewModels
 		}
 	}
 }
-

--- a/Metasia.Editor/ViewModels/MainWindowViewModel.cs
+++ b/Metasia.Editor/ViewModels/MainWindowViewModel.cs
@@ -39,22 +39,7 @@ namespace Metasia.Editor.ViewModels
 		public ICommand Undo { get; }
 		
 		public ICommand Redo { get; }
-
-		public bool CanUndo
-		{
-			get => _canUndo;
-			set => this.RaiseAndSetIfChanged(ref _canUndo, value);
-		}
 		
-		public bool CanRedo
-		{
-			get => _canRedo;
-			set => this.RaiseAndSetIfChanged(ref _canRedo, value);
-		}
-		
-		private bool _canUndo = false;
-		private bool _canRedo = false;
-
 
 		public MainWindowViewModel()
 		{
@@ -64,6 +49,9 @@ namespace Metasia.Editor.ViewModels
             SaveEditingProject = ReactiveCommand.Create(SaveEditingProjectExecuteAsync);
 			LoadEditingProject = ReactiveCommand.Create(LoadEditingProjectExecuteAsync);
 			CreateNewProject = ReactiveCommand.Create(CreateNewProjectExecuteAsync);
+
+			Undo = ReactiveCommand.Create(UndoExecute);
+			Redo = ReactiveCommand.Create(RedoExecute);
 			
 			PlayerParentVM = new PlayerParentViewModel();
 
@@ -123,6 +111,22 @@ namespace Metasia.Editor.ViewModels
 
 			MetasiaEditorProject editorProject = ProjectSaveLoadManager.Load(new DirectoryEntity(folder.Path.LocalPath));
 			PlayerParentVM.LoadProject(editorProject);
+		}
+		
+		private void UndoExecute()
+		{
+			if (PlayerParentVM.TargetPlayerViewModel is not null)
+			{
+				PlayerParentVM.TryUndo();
+			}
+		}
+		
+		private void RedoExecute()
+		{
+			if (PlayerParentVM.TargetPlayerViewModel is not null)
+			{
+				PlayerParentVM.TryRedo();
+			}
 		}
 	}
 }

--- a/Metasia.Editor/ViewModels/PlayerParentViewModel.cs
+++ b/Metasia.Editor/ViewModels/PlayerParentViewModel.cs
@@ -48,7 +48,7 @@ public class PlayerParentViewModel : ViewModelBase
 
     public event EventHandler? ProjectInstanceChanged;
 
-    public PlayerViewModel TargetPlayerViewModel
+    public PlayerViewModel? TargetPlayerViewModel
     {
         get => _targetPlayerViewModel;
         set
@@ -112,5 +112,27 @@ public class PlayerParentViewModel : ViewModelBase
         CurrentProject = editorProject.CreateMetasiaProject();
 
         IsPlayerShow = true;
+    }
+
+    public bool TryUndo()
+    {
+        if (TargetPlayerViewModel is null) return false;
+        if (TargetPlayerViewModel.CanUndo)
+        {
+            TargetPlayerViewModel.Undo();
+            return true;
+        }
+        return false;
+    }
+    
+    public bool TryRedo()
+    {
+        if (TargetPlayerViewModel is null) return false;
+        if (TargetPlayerViewModel.CanRedo)
+        {
+            TargetPlayerViewModel.Redo();
+            return true;
+        }
+        return false;
     }
 }

--- a/Metasia.Editor/ViewModels/PlayerViewModel.cs
+++ b/Metasia.Editor/ViewModels/PlayerViewModel.cs
@@ -30,6 +30,8 @@ namespace Metasia.Editor.ViewModels
 		
 		public IEditCommandManager HistoryManager { get; private set; }
 
+		public event EventHandler? ProjectChanged;
+
 		/// <summary>
 		/// 再生中であるか否か
 		/// </summary>
@@ -150,7 +152,9 @@ namespace Metasia.Editor.ViewModels
 			if(IsPlaying == false) ViewPaintRequest?.Invoke();
 
 			SliderMaximum = TargetTimeline.EndFrame;
-		}
+
+            ProjectChanged?.Invoke(this, EventArgs.Empty);
+        }
 
 	}
 }

--- a/Metasia.Editor/ViewModels/PlayerViewModel.cs
+++ b/Metasia.Editor/ViewModels/PlayerViewModel.cs
@@ -129,6 +129,18 @@ namespace Metasia.Editor.ViewModels
 			return true;
 		}
 
+		public void Undo()
+		{
+			HistoryManager.Undo();
+			NotifyProjectChanged();
+		}
+		
+		public void Redo()
+		{
+			HistoryManager.Redo();
+			NotifyProjectChanged();
+		}
+
 		/// <summary>
 		/// プロジェクトに変更が加わったらこれを呼び出す
 		/// </summary>

--- a/Metasia.Editor/ViewModels/PlayerViewModel.cs
+++ b/Metasia.Editor/ViewModels/PlayerViewModel.cs
@@ -8,6 +8,7 @@ using DynamicData;
 using Metasia.Core.Coordinate;
 using Metasia.Core.Objects;
 using Metasia.Core.Project;
+using Metasia.Editor.Models.EditCommands;
 using ReactiveUI;
 using SkiaSharp;
 
@@ -26,6 +27,8 @@ namespace Metasia.Editor.ViewModels
 		public ProjectInfo TargetProjectInfo { get; private set; }
 		
 		public TimelineObject TargetTimeline { get; private set; }
+		
+		public IEditCommandManager HistoryManager { get; private set; }
 
 		/// <summary>
 		/// 再生中であるか否か
@@ -75,10 +78,15 @@ namespace Metasia.Editor.ViewModels
         public ICommand PreviousFrame { get; }
 		public ICommand Play { get; }
 		public ICommand Pause { get; }
+		
+		public bool CanUndo => HistoryManager.CanUndo;
+		public bool CanRedo => HistoryManager.CanRedo;
+		
 		public PlayerViewModel(TimelineObject targetTimeline, ProjectInfo projectInfo)
 		{
 			TargetTimeline = targetTimeline;
 			TargetProjectInfo = projectInfo;
+			HistoryManager = new EditCommandManager();
 
             NextFrame = ReactiveCommand.Create(() =>
             {
@@ -106,10 +114,19 @@ namespace Metasia.Editor.ViewModels
 
             NotifyProjectChanged();
 		}
+		
+		
 
 		private void Timer_Elapsed(object? sender, ElapsedEventArgs e)
 		{
 			Frame++;
+		}
+		
+		public bool RunEditCommand(IEditCommand command)
+		{
+			HistoryManager.Execute(command);
+			NotifyProjectChanged();
+			return true;
 		}
 
 		/// <summary>

--- a/Metasia.Editor/ViewModels/TimelineViewModel.cs
+++ b/Metasia.Editor/ViewModels/TimelineViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Metasia.Editor.Models.EditCommands;
 
 namespace Metasia.Editor.ViewModels
 {
@@ -99,7 +100,7 @@ namespace Metasia.Editor.ViewModels
             
             foreach (var layer in Timeline.Layers)
             {
-                LayerButtons.Add(new LayerButtonViewModel(layer));
+                LayerButtons.Add(new LayerButtonViewModel(this, layer));
                 LayerCanvas.Add(new LayerCanvasViewModel(this, layer));
             }
 
@@ -116,6 +117,11 @@ namespace Metasia.Editor.ViewModels
                     playerViewModel.SelectingObjects.Add(targetClip.TargetObject);
                 }
             });
+        }
+
+        public bool RunEditCommand(IEditCommand command)
+        {
+            return playerViewModel.RunEditCommand(command);
         }
 
         public void SetFrameFromPosition(double position)

--- a/Metasia.Editor/ViewModels/TimelineViewModel.cs
+++ b/Metasia.Editor/ViewModels/TimelineViewModel.cs
@@ -145,6 +145,29 @@ namespace Metasia.Editor.ViewModels
             SelectClip.Clear();
             SelectClip.Add(clip);
         }
+
+        public bool CanResizeClip(MetasiaObject clipObject, int newStartFrame, int newEndFrame)
+        {
+            LayerObject? ownerLayer = FindOwnerLayer(clipObject);
+
+            if (ownerLayer is not null)
+            {
+                return ownerLayer.CanPlaceObjectAt(clipObject, newStartFrame, newEndFrame);
+            }
+            return false;
+        }
+
+        private LayerObject? FindOwnerLayer(MetasiaObject targetObject)
+        {
+            foreach (var layer in Timeline.Layers)
+            {
+                if (layer.Objects.Any(x => x.Id == targetObject.Id))
+                {
+                    return layer;
+                }
+            }
+            return null;
+        }
         
         private void ChangeFramePerDIP()
         {

--- a/Metasia.Editor/ViewModels/TimelineViewModel.cs
+++ b/Metasia.Editor/ViewModels/TimelineViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Metasia.Editor.Models.EditCommands;
+using Avalonia.Layout;
 
 namespace Metasia.Editor.ViewModels
 {
@@ -97,7 +98,17 @@ namespace Metasia.Editor.ViewModels
                 // タイムラインの更新が必要な場合はここで行う
                 CursorLeft = playerViewModel.Frame * Frame_Per_DIP;
             };
-            
+
+            //プロジェクトに変更が加えられたときの動作
+            playerViewModel.ProjectChanged += (sender, args) =>
+            {
+                //レイヤーにあるクリップのサイズを再計算
+                foreach (var layer in LayerCanvas)
+                {
+                    layer.RecalculateSize();
+                }
+            };
+
             foreach (var layer in Timeline.Layers)
             {
                 LayerButtons.Add(new LayerButtonViewModel(this, layer));

--- a/Metasia.Editor/Views/Controls/ClipView.axaml
+++ b/Metasia.Editor/Views/Controls/ClipView.axaml
@@ -14,8 +14,15 @@
 	<Border x:Name="Clip" Tapped="Clip_OnTapped"
 			BorderBrush="DarkGray" Background="Pink" BorderThickness="1" CornerRadius="10" ClipToBounds="True"
 	        Opacity="{Binding IsSelecting, Converter={StaticResource ClipConverter}}">
-		<RelativePanel>
-			<TextBlock Text="オブジェクト" Padding="5" RelativePanel.AlignVerticalCenterWithPanel="True"/>
-		</RelativePanel>
+		<Grid ColumnDefinitions="Auto,*,Auto">
+			<Border Grid.Column="0" x:Name="StartHandle" Width="10" Background="Blue" Cursor="SizeWestEast" VerticalAlignment="Stretch" HorizontalAlignment="Left"
+					PointerPressed="Handle_PointerPressed" PointerMoved="Handle_PointerMoved" PointerReleased="Handle_PointerReleased"/>
+			<RelativePanel Grid.Column="1">
+				<TextBlock Text="オブジェクト" Padding="5" RelativePanel.AlignVerticalCenterWithPanel="True"/>
+			</RelativePanel>
+			<Border Grid.Column="2" x:Name="EndHandle" Width="10" Background="Green" Cursor="SizeWestEast" VerticalAlignment="Stretch" HorizontalAlignment="Right"
+                    PointerPressed="Handle_PointerPressed" PointerMoved="Handle_PointerMoved" PointerReleased="Handle_PointerReleased"/>
+		</Grid>
+
 	</Border>
 </UserControl>

--- a/Metasia.Editor/Views/Controls/ClipView.axaml.cs
+++ b/Metasia.Editor/Views/Controls/ClipView.axaml.cs
@@ -31,7 +31,8 @@ public partial class ClipView : UserControl
 
     private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if(VM is null || sender is not Border handle) return;
+        //ViewModelがnullか、Borderからのイベントであれば何もしない
+        if (VM is null || sender is not Border handle) return;
         if (handle.Name != "StartHandle" && handle.Name != "EndHandle")
         {
             return;
@@ -39,7 +40,10 @@ public partial class ClipView : UserControl
 
         var parentCanvas = this.Parent as Control;
         var position = e.GetCurrentPoint(parentCanvas).Position;
+
+        //ViewModelでドラッグ開始処理
         VM.StartDrag(handle.Name, position.X);
+
         e.Pointer.Capture(handle);
 
         e.Handled = true;

--- a/Metasia.Editor/Views/Controls/ClipView.axaml.cs
+++ b/Metasia.Editor/Views/Controls/ClipView.axaml.cs
@@ -28,4 +28,51 @@ public partial class ClipView : UserControl
     {
         VM.ClipClick();
     }
+
+    private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if(VM is null || sender is not Border handle) return;
+        if (handle.Name != "StartHandle" && handle.Name != "EndHandle")
+        {
+            return;
+        }
+
+        var parentCanvas = this.Parent as Control;
+        var position = e.GetCurrentPoint(parentCanvas).Position;
+        VM.StartDrag(handle.Name, position.X);
+        e.Pointer.Capture(handle);
+
+        e.Handled = true;
+    }
+
+    private void Handle_PointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (VM is null || sender is not Border handle) return;
+        if (e.Pointer.Captured == handle)
+        {
+            var parentCanvas = this.Parent as Control;
+            if (parentCanvas is null) return;
+
+            var position = e.GetCurrentPoint(parentCanvas).Position;
+
+            VM.UpdateDrag(position.X);
+            e.Handled = true;
+        }
+    }
+
+    private void Handle_PointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (VM is null || sender is not Border handle) return;
+        if (e.Pointer.Captured == handle)
+        {
+            var parentCanvas = this.Parent as Control;
+            if (parentCanvas is null) return;
+
+            var position = e.GetCurrentPoint(parentCanvas).Position;
+            VM.EndDrag(position.X);
+
+            e.Handled = true;
+        }
+        e.Pointer.Capture(null);
+    }
 }

--- a/Metasia.Editor/Views/MainWindow.axaml
+++ b/Metasia.Editor/Views/MainWindow.axaml
@@ -41,8 +41,8 @@
 
 			</MenuItem>
 			<MenuItem Header="編集">
-				<MenuItem Header="元に戻す" IsEnabled="{Binding CanUndo}"/>
-				<MenuItem Header="やり直し" IsEnabled="{Binding CanRedo}"/>
+				<MenuItem Header="元に戻す" Command="{Binding Undo}"/>
+				<MenuItem Header="やり直し" Command="{Binding Redo}"/>
 			</MenuItem>
 			<MenuItem Header="表示">
 

--- a/Metasia.Editor/Views/MainWindow.axaml
+++ b/Metasia.Editor/Views/MainWindow.axaml
@@ -41,7 +41,8 @@
 
 			</MenuItem>
 			<MenuItem Header="編集">
-
+				<MenuItem Header="元に戻す" IsEnabled="{Binding CanUndo}"/>
+				<MenuItem Header="やり直し" IsEnabled="{Binding CanRedo}"/>
 			</MenuItem>
 			<MenuItem Header="表示">
 


### PR DESCRIPTION
MainWindowViewModelからNewProjectDialogの直接的なインスタンス化を削除し、MVVMパターンに適合させました。

変更点:
- INewProjectDialogServiceインターフェースを定義し、NewProjectDialogServiceに実装を移動。
- MainWindowViewModelのコンストラクタにINewProjectDialogServiceをDI経由で注入するように変更。
- CreateNewProjectExecuteAsyncメソッドを更新し、_newProjectDialogServiceを使用して新規プロジェクトダイアログを表示するように変更。
- App.axaml.csにて、INewProjectDialogServiceとNewProjectDialogService、およびMainWindowViewModelをDIコンテナに登録。
- MainWindowのDataContextの割り当てを、DIコンテナからMainWindowViewModelを解決するように変更。

これにより、ViewModelがViewに直接依存しないようになり、テスト容易性と保守性が向上しました。