### PR TITLE
feat: カスタマイズ可能なショートカットキーとUI操作修飾キーの導入

### DIFF
--- a/Metasia.Editor/App.axaml.cs
+++ b/Metasia.Editor/App.axaml.cs
@@ -29,15 +29,16 @@ namespace Metasia.Editor
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                desktop.MainWindow = new MainWindow
-                {
-                    DataContext = new MainWindowViewModel(),
-                };
-
                 var services = new ServiceCollection();
                 services.AddSingleton<IFileDialogService>(new FileDialogService(desktop.MainWindow));
                 services.AddSingleton<INewProjectDialogService, NewProjectDialogService>();
+                services.AddSingleton<IKeyBindingService, KeyBindingService>();
                 Services = services.BuildServiceProvider();
+
+                desktop.MainWindow = new MainWindow
+                {
+                    DataContext = new MainWindowViewModel(Services),
+                };
             }
 
             base.OnFrameworkInitializationCompleted();

--- a/Metasia.Editor/Models/KeyBindings/CommandIdentifier.cs
+++ b/Metasia.Editor/Models/KeyBindings/CommandIdentifier.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace Metasia.Editor.Models.KeyBindings
+{
+    /// <summary>
+    /// ショートカットキーを割り当てるアクションを識別するための列挙型
+    /// </summary>
+    public enum CommandIdentifier
+    {
+        /// <summary>
+        /// プロジェクトの保存
+        /// </summary>
+        SaveProject,
+        
+        /// <summary>
+        /// 元に戻す
+        /// </summary>
+        Undo,
+        
+        /// <summary>
+        /// やり直し
+        /// </summary>
+        Redo,
+        
+        /// <summary>
+        /// プロジェクトを開く
+        /// </summary>
+        OpenProject,
+        
+        /// <summary>
+        /// 新規プロジェクト作成
+        /// </summary>
+        NewProject
+    }
+}

--- a/Metasia.Editor/Models/KeyBindings/InteractionIdentifier.cs
+++ b/Metasia.Editor/Models/KeyBindings/InteractionIdentifier.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Metasia.Editor.Models.KeyBindings
+{
+    /// <summary>
+    /// マウス操作と組み合わせて使用するUIインタラクションを識別するための列挙型
+    /// </summary>
+    public enum InteractionIdentifier
+    {
+        /// <summary>
+        /// 複数選択
+        /// </summary>
+        MultiSelect
+    }
+}

--- a/Metasia.Editor/Services/IKeyBindingService.cs
+++ b/Metasia.Editor/Services/IKeyBindingService.cs
@@ -1,0 +1,36 @@
+using System;
+using Avalonia.Input;
+using Metasia.Editor.Models.KeyBindings;
+
+namespace Metasia.Editor.Services
+{
+    /// <summary>
+    /// キーバインディングを管理するサービスのインターフェース
+    /// </summary>
+    public interface IKeyBindingService
+    {
+        /// <summary>
+        /// 指定されたコマンドに対応するキーの組み合わせを取得する
+        /// </summary>
+        /// <param name="command">コマンド識別子</param>
+        /// <returns>キーの組み合わせ</returns>
+        KeyGesture GetGesture(CommandIdentifier command);
+
+        /// <summary>
+        /// 指定されたインタラクションに割り当てられた修飾キーを取得する
+        /// </summary>
+        /// <param name="interaction">インタラクション識別子</param>
+        /// <returns>修飾キー</returns>
+        KeyModifiers GetModifiers(InteractionIdentifier interaction);
+
+        /// <summary>
+        /// 設定ファイルからキーバインディングを読み込む
+        /// </summary>
+        void LoadKeyBindings();
+
+        /// <summary>
+        /// 現在のキーバインディングを設定ファイルに保存する
+        /// </summary>
+        void SaveKeyBindings();
+    }
+}

--- a/Metasia.Editor/Services/KeyBindingService.cs
+++ b/Metasia.Editor/Services/KeyBindingService.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Avalonia.Input;
+using Metasia.Editor.Models.KeyBindings;
+
+namespace Metasia.Editor.Services
+{
+    /// <summary>
+    /// キーバインディングを管理するサービスの実装
+    /// </summary>
+    public class KeyBindingService : IKeyBindingService
+    {
+        private readonly Dictionary<CommandIdentifier, KeyGesture> _commandGestures;
+        private readonly Dictionary<InteractionIdentifier, KeyModifiers> _interactionModifiers;
+        private readonly string _keyBindingsFilePath;
+
+        public KeyBindingService()
+        {
+            _commandGestures = new Dictionary<CommandIdentifier, KeyGesture>();
+            _interactionModifiers = new Dictionary<InteractionIdentifier, KeyModifiers>();
+            
+            // 設定ファイルのパスを決定
+            string appDataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "Metasia");
+            
+            // ディレクトリが存在しない場合は作成
+            if (!Directory.Exists(appDataPath))
+            {
+                Directory.CreateDirectory(appDataPath);
+            }
+            
+            _keyBindingsFilePath = Path.Combine(appDataPath, "keybindings.json");
+            
+            // 設定を読み込む
+            LoadKeyBindings();
+        }
+
+        /// <summary>
+        /// 指定されたコマンドに対応するキーの組み合わせを取得する
+        /// </summary>
+        public KeyGesture GetGesture(CommandIdentifier command)
+        {
+            if (_commandGestures.TryGetValue(command, out var gesture))
+            {
+                return gesture;
+            }
+            
+            // 登録されていない場合はデフォルト値を返す
+            return GetDefaultGesture(command);
+        }
+
+        /// <summary>
+        /// 指定されたインタラクションに割り当てられた修飾キーを取得する
+        /// </summary>
+        public KeyModifiers GetModifiers(InteractionIdentifier interaction)
+        {
+            if (_interactionModifiers.TryGetValue(interaction, out var modifiers))
+            {
+                return modifiers;
+            }
+            
+            // 登録されていない場合はデフォルト値を返す
+            return GetDefaultModifiers(interaction);
+        }
+
+        /// <summary>
+        /// 設定ファイルからキーバインディングを読み込む
+        /// </summary>
+        public void LoadKeyBindings()
+        {
+            try
+            {
+                if (File.Exists(_keyBindingsFilePath))
+                {
+                    string json = File.ReadAllText(_keyBindingsFilePath);
+                    var settings = JsonSerializer.Deserialize<KeyBindingSettings>(json);
+                    
+                    if (settings != null)
+                    {
+                        // コマンドのキーバインディングを読み込む
+                        if (settings.CommandGestures != null)
+                        {
+                            _commandGestures.Clear();
+                            foreach (var item in settings.CommandGestures)
+                            {
+                                if (Enum.TryParse<CommandIdentifier>(item.Key, out var command) &&
+                                    TryParseKeyGesture(item.Value, out var gesture))
+                                {
+                                    _commandGestures[command] = gesture;
+                                }
+                            }
+                        }
+                        
+                        // インタラクションの修飾キーを読み込む
+                        if (settings.InteractionModifiers != null)
+                        {
+                            _interactionModifiers.Clear();
+                            foreach (var item in settings.InteractionModifiers)
+                            {
+                                if (Enum.TryParse<InteractionIdentifier>(item.Key, out var interaction) &&
+                                    Enum.TryParse<KeyModifiers>(item.Value, out var modifiers))
+                                {
+                                    _interactionModifiers[interaction] = modifiers;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"キーバインディングの読み込みに失敗しました: {ex.Message}");
+            }
+            
+            // デフォルト値を設定
+            SetDefaultKeyBindings();
+        }
+
+        /// <summary>
+        /// 現在のキーバインディングを設定ファイルに保存する
+        /// </summary>
+        public void SaveKeyBindings()
+        {
+            try
+            {
+                var settings = new KeyBindingSettings
+                {
+                    CommandGestures = new Dictionary<string, string>(),
+                    InteractionModifiers = new Dictionary<string, string>()
+                };
+                
+                // コマンドのキーバインディングを保存
+                foreach (var item in _commandGestures)
+                {
+                    settings.CommandGestures[item.Key.ToString()] = item.Value.ToString();
+                }
+                
+                // インタラクションの修飾キーを保存
+                foreach (var item in _interactionModifiers)
+                {
+                    settings.InteractionModifiers[item.Key.ToString()] = item.Value.ToString();
+                }
+                
+                string json = JsonSerializer.Serialize(settings, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+                
+                File.WriteAllText(_keyBindingsFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"キーバインディングの保存に失敗しました: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// デフォルトのキーバインディングを設定する
+        /// </summary>
+        private void SetDefaultKeyBindings()
+        {
+            // コマンドのデフォルトキーバインディングを設定
+            foreach (CommandIdentifier command in Enum.GetValues(typeof(CommandIdentifier)))
+            {
+                if (!_commandGestures.ContainsKey(command))
+                {
+                    _commandGestures[command] = GetDefaultGesture(command);
+                }
+            }
+            
+            // インタラクションのデフォルト修飾キーを設定
+            foreach (InteractionIdentifier interaction in Enum.GetValues(typeof(InteractionIdentifier)))
+            {
+                if (!_interactionModifiers.ContainsKey(interaction))
+                {
+                    _interactionModifiers[interaction] = GetDefaultModifiers(interaction);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 指定されたコマンドのデフォルトのキーの組み合わせを取得する
+        /// </summary>
+        private KeyGesture GetDefaultGesture(CommandIdentifier command)
+        {
+            return command switch
+            {
+                CommandIdentifier.SaveProject => new KeyGesture(Key.S, KeyModifiers.Control),
+                CommandIdentifier.Undo => new KeyGesture(Key.Z, KeyModifiers.Control),
+                CommandIdentifier.Redo => new KeyGesture(Key.Y, KeyModifiers.Control),
+                CommandIdentifier.OpenProject => new KeyGesture(Key.O, KeyModifiers.Control),
+                CommandIdentifier.NewProject => new KeyGesture(Key.N, KeyModifiers.Control),
+                _ => new KeyGesture(Key.None)
+            };
+        }
+
+        /// <summary>
+        /// 指定されたインタラクションのデフォルトの修飾キーを取得する
+        /// </summary>
+        private KeyModifiers GetDefaultModifiers(InteractionIdentifier interaction)
+        {
+            return interaction switch
+            {
+                InteractionIdentifier.MultiSelect => KeyModifiers.Control,
+                _ => KeyModifiers.None
+            };
+        }
+
+        /// <summary>
+        /// 文字列からKeyGestureを解析する
+        /// </summary>
+        private bool TryParseKeyGesture(string gestureString, out KeyGesture gesture)
+        {
+            gesture = null;
+            
+            try
+            {
+                gesture = KeyGesture.Parse(gestureString);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// キーバインディング設定のJSONシリアライズ用クラス
+    /// </summary>
+    internal class KeyBindingSettings
+    {
+        public Dictionary<string, string> CommandGestures { get; set; }
+        public Dictionary<string, string> InteractionModifiers { get; set; }
+    }
+}

--- a/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
+++ b/Metasia.Editor/ViewModels/Controls/ClipViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Input;
 using Metasia.Core.Objects;
 using Metasia.Editor.Models.EditCommands;
 using Metasia.Editor.Models.EditCommands.Commands;
@@ -90,9 +91,21 @@ namespace Metasia.Editor.ViewModels.Controls
             StartFrame = TargetObject.StartFrame * Frame_Per_DIP;
         }
 
+        /// <summary>
+        /// クリップがクリックされたときの処理
+        /// </summary>
+        /// <param name="modifiers">押されていた修飾キー</param>
+        public void ClipClick(KeyModifiers modifiers = KeyModifiers.None)
+        {
+            parentTimeline.ClipSelect(this, modifiers);
+        }
+
+        /// <summary>
+        /// 後方互換性のためのクリックメソッド
+        /// </summary>
         public void ClipClick()
         {
-            parentTimeline.ClipSelect(this);
+            ClipClick(KeyModifiers.None);
         }
 
         /// <summary>

--- a/Metasia.Editor/Views/Controls/ClipView.axaml.cs
+++ b/Metasia.Editor/Views/Controls/ClipView.axaml.cs
@@ -26,7 +26,13 @@ public partial class ClipView : UserControl
 
     private void Clip_OnTapped(object? sender, TappedEventArgs e)
     {
-        VM.ClipClick();
+        if (VM is null) return;
+        
+        // 修飾キーの状態を取得
+        var modifiers = e.KeyModifiers;
+        
+        // 修飾キーの状態を含めてクリックイベントを発火
+        VM.ClipClick(modifiers);
     }
 
     private void Handle_PointerPressed(object? sender, PointerPressedEventArgs e)

--- a/Metasia.Editor/Views/MainWindow.axaml.cs
+++ b/Metasia.Editor/Views/MainWindow.axaml.cs
@@ -1,12 +1,67 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Metasia.Editor.Models.KeyBindings;
+using Metasia.Editor.Services;
+using Metasia.Editor.ViewModels;
+using System;
+using System.Collections.Generic;
 
 namespace Metasia.Editor.Views
 {
 	public partial class MainWindow : Window
 	{
+		private MainWindowViewModel ViewModel => DataContext as MainWindowViewModel;
+		private IKeyBindingService _keyBindingService;
+
 		public MainWindow()
 		{
 			InitializeComponent();
+			
+			// ウィンドウがロードされたときにキーバインディングを登録
+			this.Loaded += MainWindow_Loaded;
+		}
+
+		private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+		{
+			if (ViewModel == null) return;
+			
+			// キーバインディングサービスを取得
+			_keyBindingService = App.Current?.Services?.GetService(typeof(IKeyBindingService)) as IKeyBindingService;
+			if (_keyBindingService == null) return;
+			
+			// キーバインディングを登録
+			RegisterKeyBindings();
+		}
+
+		/// <summary>
+		/// キーバインディングを登録する
+		/// </summary>
+		private void RegisterKeyBindings()
+		{
+			if (ViewModel?.CommandMap == null || _keyBindingService == null) return;
+
+			// 既存のキーバインディングをクリア
+			this.KeyBindings.Clear();
+
+			// 各コマンドに対応するキーバインディングを登録
+			foreach (var commandEntry in ViewModel.CommandMap)
+			{
+				var commandId = commandEntry.Key;
+				var command = commandEntry.Value;
+				
+				// キーバインディングサービスからキージェスチャーを取得
+				var gesture = _keyBindingService.GetGesture(commandId);
+				
+				// キーバインディングを作成して登録
+				var keyBinding = new KeyBinding
+				{
+					Command = command,
+					Gesture = gesture
+				};
+				
+				this.KeyBindings.Add(keyBinding);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 変更点

このプルリクエストでは、ユーザーの操作効率を向上させるために以下の機能を追加しました：

1. **カスタマイズ可能なショートカットキー**
   - `IKeyBindingService` インターフェースと `KeyBindingService` 実装を追加
   - 「保存」（Ctrl+S）、「元に戻す」（Ctrl+Z）、「やり直し」（Ctrl+Y）などの基本操作にショートカットキーを割り当て
   - 設定ファイル（keybindings.json）からキー設定を読み込む機能を実装
   - デフォルト設定を提供しつつ、ユーザーによるカスタマイズを可能に

2. **複数選択のための修飾キー**
   - タイムライン上のクリップを複数選択できるよう、修飾キー（デフォルトはCtrl）を使った選択機能を実装
   - 修飾キーを押しながらクリックすると選択が追加され、選択済みのクリップをクリックすると選択解除
   - 修飾キーなしでクリックすると単一選択モードに

3. **拡張性の高い設計**
   - `CommandIdentifier` と `InteractionIdentifier` の列挙型を導入し、将来的な機能拡張に対応
   - DIコンテナを活用した疎結合な設計

## 技術的な詳細

- `KeyBindingService` は設定ファイルからキー設定を読み込み、存在しない場合はデフォルト設定を適用
- `MainWindowViewModel` に `CommandMap` を追加し、コマンド識別子と `ICommand` を紐付け
- `MainWindow` の `Loaded` イベントで動的にキーバインディングを登録
- `TimelineViewModel` に修飾キーを考慮した選択ロジックを実装

このプルリクエストはOpenHandsによって作成されました。

@SousiOmine can click here to [continue refining the PR](https://app.all-hands.dev/2ca43efd4e644a869d4cb919792801bb)