### PR TITLE
Fix project save/load functionality to preserve custom settings

### DIFF
--- a/Metasia.Editor.Tests/Models/Projects/ProjectSaveLoadTests.cs
+++ b/Metasia.Editor.Tests/Models/Projects/ProjectSaveLoadTests.cs
@@ -1,0 +1,68 @@
+
+using NUnit.Framework;
+using Metasia.Editor.Models.FileSystem;
+using Metasia.Editor.Models.Projects;
+using Metasia.Editor.Models;
+using System.IO;
+
+namespace Metasia.Editor.Tests.Models.Projects
+{
+    [TestFixture]
+    public class ProjectSaveLoadTests
+    {
+        private string _testDirectory;
+        private DirectoryEntity _projectPath;
+
+        [SetUp]
+        public void Setup()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "ProjectSaveLoadTests");
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+            Directory.CreateDirectory(_testDirectory);
+            Directory.CreateDirectory(Path.Combine(_testDirectory, "./Timelines")); // Create expected timeline folder
+            _projectPath = new DirectoryEntity(_testDirectory);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+        }
+
+        [Test]
+        public void Save_Load_PreservesProjectSettings()
+        {
+            // Arrange
+            var projectFile = new MetasiaProjectFile
+            {
+                Framerate = 30,
+                Resolution = new VideoResolution { Width = 1280, Height = 720 },
+                RootTimelineId = "CustomTimeline"
+            };
+
+            var editorProject = new MetasiaEditorProject(_projectPath, projectFile);
+
+            // Act - Save the project
+            ProjectSaveLoadManager.Save(editorProject);
+
+            // Verify the file was created
+            string metasiaJsonPath = Path.Combine(_testDirectory, "metasia.json");
+            Assert.That(File.Exists(metasiaJsonPath), Is.True);
+
+            // Act - Load the project
+            var loadedProject = ProjectSaveLoadManager.Load(_projectPath);
+
+            // Assert - Verify settings are preserved
+            Assert.That(loadedProject.ProjectFile.Framerate, Is.EqualTo(30));
+            Assert.That(loadedProject.ProjectFile.Resolution.Width, Is.EqualTo(1280));
+            Assert.That(loadedProject.ProjectFile.Resolution.Height, Is.EqualTo(720));
+            Assert.That(loadedProject.ProjectFile.RootTimelineId, Is.EqualTo("CustomTimeline"));
+        }
+    }
+}

--- a/Metasia.Editor/Models/ProjectSaveLoadManager.cs
+++ b/Metasia.Editor/Models/ProjectSaveLoadManager.cs
@@ -19,7 +19,7 @@ public class ProjectSaveLoadManager
             WriteIndented = true,
             IncludeFields = true,
         };
-        string jsonString = JsonSerializer.Serialize(editorProject, options);
+        string jsonString = JsonSerializer.Serialize(editorProject.ProjectFile, options);
         File.WriteAllText(Path.Combine(editorProject.ProjectPath.Path, "metasia.json"), jsonString);
 
         foreach (var timeline in editorProject.Timelines)


### PR DESCRIPTION
このプルリクエストは、Metasia Editorのプロジェクト保存・読み込み機能の不具合を修正します。

### 修正内容
- `ProjectSaveLoadManager.Save()`メソッドを修正し、シリアライズ対象を`editorProject`全体から`editorProject.ProjectFile`プロパティに変更
- これにより、保存と読み込みの処理が正しく対応し、ユーザーが設定した値（解像度、フレームレートなど）が反映されるようになります

### 詳細
元々のコードでは、`Save()`メソッドが`MetasiaEditorProject`オブジェクト全体をシリアライズしていましたが、`Load()`メソッドは`MetasiaProjectFile`型を読み込もうとしていました。これにより、プロジェクト設定が保存されず、常にデフォルト値で開かれてしまう問題がありました。

### テスト
- 新しいテスト`ProjectSaveLoadTests.cs`を追加し、カスタム設定が保存・読み込みされることを確認
- 既存の全てのテストも引き続き通過します

### ビルド確認
- 修正後、プロジェクトのビルドが通ることを確認済み
- 修正は最小限に抑え、コードの品質を保ちながら問題を解決しています

このプルリクエストはOpenHandsによって作成されました。