### PR TITLE
Fix JSON encoding to preserve Japanese characters in readable form

### DIFF
--- a/Metasia.Core/Json/MetasiaObjectJsonConverter.cs
+++ b/Metasia.Core/Json/MetasiaObjectJsonConverter.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Metasia.Core.Objects;
 using System.Diagnostics;
 
@@ -49,11 +51,13 @@ public class MetasiaObjectJsonConverter : JsonConverter<MetasiaObject>
         // - 大文字小文字を区別しない
         // - フィールドを含める
         // - 列挙型を文字列として扱う
+        // - 2バイト文字をエスケープしない
         var serializerOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
             IncludeFields = true,
-            Converters = { new JsonStringEnumConverter(), this }
+            Converters = { new JsonStringEnumConverter(), this },
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         try
@@ -79,7 +83,8 @@ public class MetasiaObjectJsonConverter : JsonConverter<MetasiaObject>
         {
             PropertyNameCaseInsensitive = true,
             IncludeFields = true,
-            Converters = { new JsonStringEnumConverter(), this }
+            Converters = { new JsonStringEnumConverter(), this },
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         // オブジェクトをJSON文字列に変換

--- a/Metasia.Core/Json/ProjectSerializer.cs
+++ b/Metasia.Core/Json/ProjectSerializer.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Metasia.Core.Project;
 
 namespace Metasia.Core.Json
@@ -16,7 +18,8 @@ namespace Metasia.Core.Json
             {
                 WriteIndented = true,
                 IncludeFields = true,
-                Converters = { new MetasiaObjectJsonConverter() }
+                Converters = { new MetasiaObjectJsonConverter() },
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             };
             return JsonSerializer.Serialize(project, options);
         }

--- a/Metasia.Core/Json/TimelineSerializer.cs
+++ b/Metasia.Core/Json/TimelineSerializer.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using Metasia.Core.Objects;
 using Metasia.Core.Project;
 
@@ -15,7 +17,8 @@ namespace Metasia.Core.Json
             {
                 WriteIndented = true,
                 IncludeFields = true,
-                Converters = { new MetasiaObjectJsonConverter() }
+                Converters = { new MetasiaObjectJsonConverter() },
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             };
             return JsonSerializer.Serialize(timeline, options);
         }


### PR DESCRIPTION

## 概要
JSONファイルに保存される2バイト文字（日本語など）がUnicodeエスケープシーケンス（\uXXXX形式）に変換されてしまい、可読性が低くなる問題を修正しました。

## 変更内容
- `ProjectSerializer.cs`、`TimelineSerializer.cs`、`MetasiaObjectJsonConverter.cs` の3つのJSONシリアライズ関連ファイルに修正を加えました
- 各ファイルの `JsonSerializerOptions` に `Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping` を設定することで、非ASCII文字がエスケープされずにそのまま保存されるようにしました
- 必要な using ディレクティブ（`System.Text.Encodings.Web` と `System.Text.Unicode`）を追加しました

## 技術的詳細
`JavaScriptEncoder.UnsafeRelaxedJsonEscaping` を使用することで、JSONシリアライザが日本語などの2バイト文字をUnicodeエスケープシーケンスに変換せず、可読性の高い状態でJSONファイルに保存されるようになります。

## テスト
実際に日本語を含むプロジェクトを作成し、JSONシリアライズ・デシリアライズが正常に動作することを確認しました。日本語文字がエスケープされずに保存されることを検証済みです。

## 影響範囲
- プロジェクトファイル（.mtpj）の可読性が向上します
- タイムラインファイルの可読性が向上します
- 既存のファイルとの互換性は維持されます（デシリアライズは正常に動作します）
